### PR TITLE
Ensure Supabase realtime connections include auth headers

### DIFF
--- a/student-supabase.html
+++ b/student-supabase.html
@@ -349,6 +349,30 @@
           "inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-sm font-semibold tracking-tight text-slate-600 ring-1 ring-slate-200 bg-slate-100",
       };
 
+      function createSupabaseClient() {
+        return createClient(
+          window.SUPABASE_URL,
+          window.SUPABASE_ANON_KEY,
+          {
+            auth: {
+              persistSession: false,
+              autoRefreshToken: false,
+            },
+            global: {
+              headers: {
+                apikey: window.SUPABASE_ANON_KEY,
+                Authorization: `Bearer ${window.SUPABASE_ANON_KEY}`,
+              },
+            },
+            realtime: {
+              params: {
+                apikey: window.SUPABASE_ANON_KEY,
+              },
+            },
+          },
+        );
+      }
+
       let supabase, channel;
       let username, sessionCode;
       let isDrawing = false;
@@ -912,10 +936,7 @@
         updateStatus("connecting", "Connecting…");
 
         try {
-          supabase = createClient(
-            window.SUPABASE_URL,
-            window.SUPABASE_ANON_KEY,
-          );
+          supabase = createSupabaseClient();
           channel = supabase.channel(`minimal-${sessionCode}`, {
             config: { broadcast: { ack: false } },
           });

--- a/teacher-supabase.html
+++ b/teacher-supabase.html
@@ -467,6 +467,30 @@
           "inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-semibold tracking-tight text-rose-700 ring-1 ring-rose-200 bg-rose-50",
       };
 
+      function createSupabaseClient() {
+        return createClient(
+          window.SUPABASE_URL,
+          window.SUPABASE_ANON_KEY,
+          {
+            auth: {
+              persistSession: false,
+              autoRefreshToken: false,
+            },
+            global: {
+              headers: {
+                apikey: window.SUPABASE_ANON_KEY,
+                Authorization: `Bearer ${window.SUPABASE_ANON_KEY}`,
+              },
+            },
+            realtime: {
+              params: {
+                apikey: window.SUPABASE_ANON_KEY,
+              },
+            },
+          },
+        );
+      }
+
       let supabase, channel;
       let sessionCode;
       let students = new Map();
@@ -743,10 +767,7 @@
             return;
           }
 
-          supabase = createClient(
-            window.SUPABASE_URL,
-            window.SUPABASE_ANON_KEY,
-          );
+          supabase = createSupabaseClient();
 
           channel = supabase.channel(`minimal-${sessionCode}`, {
             config: { broadcast: { ack: false } },


### PR DESCRIPTION
## Summary
- add a shared helper on the teacher and student pages to build the Supabase client with consistent auth options
- send the anon key in both headers and realtime params to avoid realtime websocket authentication failures

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcb4664034832791ea82149784c722