### PR TITLE
Add shared classroom presence for student and teacher views

### DIFF
--- a/student-app.js
+++ b/student-app.js
@@ -1,0 +1,228 @@
+import initCanvasApp from './canvas-app.js';
+
+const loginForm = document.getElementById('loginForm');
+const appContainer = document.getElementById('appContainer');
+const loginBtn = document.getElementById('loginBtn');
+const usernameInput = document.getElementById('usernameInput');
+const sessionInput = document.getElementById('sessionInput');
+const statusButton = document.getElementById('status');
+const statusText = document.getElementById('statusText');
+const connectionLabel = document.getElementById('connectionLabel');
+const loginError = document.getElementById('loginError');
+
+const STORAGE_KEY = 'liveDrawing.student';
+const presenceChannel = typeof BroadcastChannel === 'function' ? new BroadcastChannel('classroom-presence') : null;
+
+const canvasApp = initCanvasApp({
+  root: document.getElementById('studentCanvasApp'),
+  stage: document.getElementById('studentStage'),
+  canvas: document.getElementById('studentPad'),
+  colorButtons: [...document.querySelectorAll('#studentCanvasApp [data-color]')],
+  toolButtons: [...document.querySelectorAll('#studentCanvasApp [data-tool]')],
+  undoButton: document.getElementById('studentUndoBtn'),
+  redoButton: document.getElementById('studentRedoBtn'),
+  clearButton: document.getElementById('studentClearBtn'),
+  stylusToggle: document.getElementById('studentStylusBtn'),
+  sizeSlider: document.getElementById('studentBrush'),
+  sizeLabel: document.getElementById('studentSizeLabel'),
+  sizePreview: document.getElementById('studentSizePreview'),
+  statusElement: document.getElementById('studentCanvasStatus'),
+  statusText: document.getElementById('studentCanvasStatusText'),
+  role: 'student',
+  remoteLabel: 'teacher',
+  channelName: 'classroom-canvas',
+});
+
+let currentStudent = null;
+
+function showApp(){
+  if(loginForm){
+    loginForm.classList.add('hidden');
+  }
+  if(appContainer){
+    appContainer.classList.remove('hidden');
+  }
+}
+
+function showLogin(){
+  if(appContainer){
+    appContainer.classList.add('hidden');
+  }
+  if(loginForm){
+    loginForm.classList.remove('hidden');
+  }
+}
+
+function setStatus(state, message){
+  if(!statusButton) return;
+  statusButton.classList.remove('status-dot--connected', 'status-dot--error');
+  if(state === 'connected'){
+    statusButton.classList.add('status-dot--connected');
+  }else if(state === 'error'){
+    statusButton.classList.add('status-dot--error');
+  }
+  if(statusButton){
+    statusButton.setAttribute('aria-label', message);
+    statusButton.setAttribute('title', message);
+  }
+  if(statusText){
+    statusText.textContent = message;
+  }
+}
+
+function setConnectionLabel(message){
+  if(connectionLabel){
+    connectionLabel.textContent = message;
+  }
+}
+
+function reportError(message){
+  if(loginError){
+    loginError.textContent = message;
+    loginError.classList.remove('hidden');
+  }else{
+    window.alert(message);
+  }
+  setStatus('error', message);
+}
+
+function clearError(){
+  if(loginError){
+    loginError.classList.add('hidden');
+    loginError.textContent = '';
+  }
+}
+
+function announcePresence(type){
+  if(!presenceChannel || !currentStudent) return;
+  presenceChannel.postMessage({
+    type,
+    student: {
+      ...currentStudent,
+      lastSeen: Date.now(),
+    },
+  });
+}
+
+function persistStudent(){
+  if(!currentStudent) return;
+  try{
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(currentStudent));
+  }catch(err){
+    console.warn('Failed to persist student state', err);
+  }
+}
+
+function hydrateFromStorage(){
+  try{
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if(!raw) return null;
+    const parsed = JSON.parse(raw);
+    if(parsed && typeof parsed === 'object' && parsed.name && parsed.session){
+      return parsed;
+    }
+  }catch(err){
+    console.warn('Failed to parse student storage', err);
+  }
+  return null;
+}
+
+function joinSession({ name, session, id }){
+  const normalizedName = (name || '').trim();
+  const normalizedSession = (session || '').trim().toUpperCase();
+  if(!normalizedName || !normalizedSession){
+    return;
+  }
+  currentStudent = {
+    id: id || (crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`),
+    name: normalizedName,
+    session: normalizedSession,
+    joinedAt: new Date().toISOString(),
+  };
+  persistStudent();
+  clearError();
+  if(usernameInput){
+    usernameInput.value = currentStudent.name;
+  }
+  if(sessionInput){
+    sessionInput.value = currentStudent.session;
+  }
+  showApp();
+  setStatus('connected', `Connected to ${currentStudent.session}`);
+  setConnectionLabel(`Connected to session ${currentStudent.session} as ${currentStudent.name}`);
+  announcePresence('student-joined');
+}
+
+function handleLogin(){
+  const name = (usernameInput?.value || '').trim();
+  const sessionCode = (sessionInput?.value || '').trim().toUpperCase();
+  if(name.length < 2){
+    reportError('Please enter your name to join.');
+    return;
+  }
+  if(!sessionCode){
+    reportError('Enter the session code you were given.');
+    return;
+  }
+  joinSession({
+    name,
+    session: sessionCode,
+    id: currentStudent?.id,
+  });
+}
+
+if(loginBtn){
+  loginBtn.addEventListener('click', (event) => {
+    event.preventDefault();
+    handleLogin();
+  });
+}
+
+if([usernameInput, sessionInput].every(Boolean)){
+  [usernameInput, sessionInput].forEach((input) => {
+    input.addEventListener('keydown', (event) => {
+      if(event.key === 'Enter'){
+        event.preventDefault();
+        handleLogin();
+      }
+    });
+    input.addEventListener('input', () => {
+      if(loginError && !loginError.classList.contains('hidden')){
+        clearError();
+        setStatus('idle', 'Waiting');
+      }
+    });
+  });
+}
+
+if(presenceChannel){
+  presenceChannel.addEventListener('message', (event) => {
+    const msg = event?.data;
+    if(!msg) return;
+    if(msg.type === 'teacher-sync-request' || msg.type === 'teacher-session-started'){
+      if(!currentStudent) return;
+      if(msg.session && msg.session !== currentStudent.session) return;
+      announcePresence('student-joined');
+    }
+  });
+}
+
+window.addEventListener('beforeunload', () => {
+  announcePresence('student-left');
+  if(canvasApp?.destroy){
+    canvasApp.destroy();
+  }
+});
+
+const saved = hydrateFromStorage();
+if(saved){
+  usernameInput.value = saved.name;
+  sessionInput.value = saved.session;
+  joinSession(saved);
+}else{
+  showLogin();
+  setStatus('idle', 'Waiting');
+  setConnectionLabel('Enter your details to join the session.');
+}
+
+export {}; // ensure module context

--- a/student-supabase.html
+++ b/student-supabase.html
@@ -84,6 +84,7 @@
       >
         Join Session
       </button>
+      <p id="loginError" class="hidden text-center text-sm font-semibold text-rose-600"></p>
     </div>
   </div>
 
@@ -94,7 +95,7 @@
     <div class="flex items-center justify-between rounded-2xl border border-emerald-100 bg-white/70 px-3 py-2.5">
       <div class="min-w-0">
         <h1 class="text-lg font-semibold tracking-tight text-slate-900">Student Canvas</h1>
-        <p id="connectionLabel" class="text-xs font-medium text-slate-500">Preparing session...</p>
+        <p id="connectionLabel" class="text-xs font-medium text-slate-500">Enter your details to join the session.</p>
       </div>
       <div class="flex items-center gap-2">
         <button
@@ -169,28 +170,6 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5dHN3c3plb3BkeG10eHhia3JiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg1NTI5ODQsImV4cCI6MjA3NDEyODk4NH0.7skddGtrUoXluvK9JDS54bpmKCxVYeofzWATmJIgABE";
   </script>
 
-  <script type="module">
-    import initCanvasApp from './canvas-app.js';
-
-    initCanvasApp({
-      root: document.getElementById('studentCanvasApp'),
-      stage: document.getElementById('studentStage'),
-      canvas: document.getElementById('studentPad'),
-      colorButtons: [...document.querySelectorAll('#studentCanvasApp [data-color]')],
-      toolButtons: [...document.querySelectorAll('#studentCanvasApp [data-tool]')],
-      undoButton: document.getElementById('studentUndoBtn'),
-      redoButton: document.getElementById('studentRedoBtn'),
-      clearButton: document.getElementById('studentClearBtn'),
-      stylusToggle: document.getElementById('studentStylusBtn'),
-      sizeSlider: document.getElementById('studentBrush'),
-      sizeLabel: document.getElementById('studentSizeLabel'),
-      sizePreview: document.getElementById('studentSizePreview'),
-      statusElement: document.getElementById('studentCanvasStatus'),
-      statusText: document.getElementById('studentCanvasStatusText'),
-      role: 'student',
-      remoteLabel: 'teacher',
-      channelName: 'classroom-canvas',
-    });
-  </script>
+  <script type="module" src="./student-app.js"></script>
 </body>
 </html>

--- a/teacher-app.js
+++ b/teacher-app.js
@@ -1,0 +1,264 @@
+import initCanvasApp from './canvas-app.js';
+
+const sessionInput = document.getElementById('sessionInput');
+const startSessionBtn = document.getElementById('startSessionBtn');
+const statusBadge = document.getElementById('status');
+const sessionInfo = document.getElementById('sessionInfo');
+const sessionCodeEl = document.getElementById('sessionCode');
+const studentCountEl = document.getElementById('studentCount');
+const studentsContainer = document.getElementById('students');
+const emptyState = document.getElementById('emptyState');
+const modal = document.getElementById('modal');
+const closeModalBtn = document.getElementById('closeModal');
+const modalTitle = document.getElementById('modalTitle');
+
+const STORAGE_KEY = 'liveDrawing.teacherSession';
+const presenceChannel = typeof BroadcastChannel === 'function' ? new BroadcastChannel('classroom-presence') : null;
+
+const teacherCanvasApp = initCanvasApp({
+  root: document.getElementById('teacherCanvasApp'),
+  stage: document.getElementById('teacherStage'),
+  canvas: document.getElementById('teacherPad'),
+  colorButtons: [...document.querySelectorAll('#teacherCanvasApp [data-color]')],
+  toolButtons: [...document.querySelectorAll('#teacherCanvasApp [data-tool]')],
+  undoButton: document.getElementById('teacherUndoBtn'),
+  redoButton: document.getElementById('teacherRedoBtn'),
+  clearButton: document.getElementById('teacherClearBtn'),
+  stylusToggle: document.getElementById('teacherStylusBtn'),
+  sizeSlider: document.getElementById('teacherBrush'),
+  sizeLabel: document.getElementById('teacherSizeLabel'),
+  sizePreview: document.getElementById('teacherSizePreview'),
+  statusElement: document.getElementById('teacherCanvasStatus'),
+  statusText: document.getElementById('teacherCanvasStatusText'),
+  role: 'teacher',
+  remoteLabel: 'student',
+  channelName: 'classroom-canvas',
+});
+
+let currentSession = null;
+const studentMap = new Map();
+let activeStudentId = null;
+
+function setStatus(text, variant = 'idle'){
+  if(!statusBadge) return;
+  const baseClasses = 'inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-semibold transition-colors duration-200';
+  const variants = {
+    idle: 'border-blue-200 bg-blue-100 text-blue-700',
+    active: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    error: 'border-rose-200 bg-rose-50 text-rose-700',
+  };
+  statusBadge.className = `${baseClasses} ${variants[variant] || variants.idle}`;
+  statusBadge.textContent = text;
+}
+
+function requestPresence(){
+  if(!presenceChannel || !currentSession) return;
+  presenceChannel.postMessage({ type: 'teacher-session-started', session: currentSession });
+  presenceChannel.postMessage({ type: 'teacher-sync-request', session: currentSession });
+}
+
+function pruneStudents(){
+  if(!currentSession) return;
+  for(const [id, student] of studentMap.entries()){
+    if(student.session !== currentSession){
+      studentMap.delete(id);
+    }
+  }
+}
+
+function createStudentCard(student){
+  const card = document.createElement('article');
+  card.className = 'flex flex-col gap-4 rounded-[24px] border border-slate-200 bg-white/80 p-5 shadow-[0_20px_45px_rgba(30,64,175,0.16)] backdrop-blur';
+
+  const header = document.createElement('div');
+  header.className = 'flex items-center justify-between gap-3';
+
+  const identity = document.createElement('div');
+  const nameEl = document.createElement('p');
+  nameEl.className = 'text-lg font-semibold text-slate-900';
+  nameEl.textContent = student.name;
+  const detailEl = document.createElement('p');
+  detailEl.className = 'text-sm text-slate-500';
+  const timestamp = student.lastSeen || Date.now();
+  detailEl.textContent = `Last seen ${new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  identity.appendChild(nameEl);
+  identity.appendChild(detailEl);
+
+  const badge = document.createElement('span');
+  badge.className = 'rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700';
+  badge.textContent = student.session;
+
+  header.append(identity, badge);
+
+  const actionRow = document.createElement('div');
+  actionRow.className = 'flex flex-wrap items-center gap-3';
+
+  const annotateBtn = document.createElement('button');
+  annotateBtn.type = 'button';
+  annotateBtn.className = 'inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-blue-900/30 transition hover:from-blue-500 hover:to-indigo-400 focus:outline-none focus:ring-4 focus:ring-blue-200';
+  annotateBtn.textContent = 'View & Annotate';
+  annotateBtn.addEventListener('click', () => openModal(student));
+
+  const statusHint = document.createElement('span');
+  statusHint.className = 'text-xs font-medium uppercase tracking-wide text-slate-400';
+  statusHint.textContent = 'Live';
+
+  actionRow.append(annotateBtn, statusHint);
+
+  card.append(header, actionRow);
+  return card;
+}
+
+function renderStudents(){
+  if(!studentsContainer || !studentCountEl || !emptyState){
+    return;
+  }
+  const sessionStudents = currentSession
+    ? [...studentMap.values()].filter((student) => student.session === currentSession)
+    : [];
+  sessionStudents.sort((a, b) => a.name.localeCompare(b.name));
+
+  studentsContainer.innerHTML = '';
+  sessionStudents.forEach((student) => {
+    studentsContainer.appendChild(createStudentCard(student));
+  });
+
+  studentCountEl.textContent = String(sessionStudents.length);
+  emptyState.classList.toggle('hidden', sessionStudents.length > 0 && !!currentSession);
+  studentsContainer.classList.toggle('hidden', sessionStudents.length === 0);
+
+  if(currentSession){
+    if(sessionStudents.length){
+      const label = sessionStudents.length === 1 ? 'student online' : 'students online';
+      setStatus(`${sessionStudents.length} ${label}`, 'active');
+    }else{
+      setStatus('Waiting for students', 'active');
+    }
+  }else{
+    setStatus('Not connected', 'idle');
+  }
+}
+
+function openModal(student){
+  if(!modal || !modalTitle) return;
+  activeStudentId = student.id;
+  modalTitle.textContent = `Annotating ${student.name}`;
+  modal.classList.remove('invisible', 'pointer-events-none');
+  document.body.classList.add('overflow-hidden');
+}
+
+function closeModalView(){
+  if(!modal) return;
+  activeStudentId = null;
+  modal.classList.add('invisible', 'pointer-events-none');
+  document.body.classList.remove('overflow-hidden');
+}
+
+function startSession({ announce = true } = {}){
+  const code = (sessionInput?.value || '').trim().toUpperCase();
+  if(!code){
+    setStatus('Enter a session code to start', 'error');
+    return;
+  }
+  currentSession = code;
+  if(sessionInput){
+    sessionInput.value = currentSession;
+  }
+  try{
+    localStorage.setItem(STORAGE_KEY, currentSession);
+  }catch(err){
+    console.warn('Failed to persist teacher session', err);
+  }
+  if(sessionInfo){
+    sessionInfo.classList.remove('hidden');
+  }
+  if(sessionCodeEl){
+    sessionCodeEl.textContent = currentSession;
+  }
+  pruneStudents();
+  renderStudents();
+  if(announce){
+    requestPresence();
+  }
+}
+
+if(startSessionBtn){
+  startSessionBtn.addEventListener('click', () => startSession({ announce: true }));
+}
+
+if(sessionInput){
+  sessionInput.addEventListener('keydown', (event) => {
+    if(event.key === 'Enter'){
+      event.preventDefault();
+      startSession({ announce: true });
+    }
+  });
+}
+
+if(presenceChannel){
+  presenceChannel.addEventListener('message', (event) => {
+    const msg = event?.data;
+    if(!msg) return;
+    if(msg.type === 'student-joined' && msg.student){
+      const { student } = msg;
+      if(!student.id) return;
+      studentMap.set(student.id, {
+        ...student,
+        lastSeen: Date.now(),
+      });
+      if(currentSession && student.session === currentSession){
+        renderStudents();
+      }
+    }else if(msg.type === 'student-left' && msg.student){
+      const { student } = msg;
+      if(!student.id) return;
+      studentMap.delete(student.id);
+      if(currentSession){
+        renderStudents();
+      }
+    }
+  });
+}
+
+if(closeModalBtn){
+  closeModalBtn.addEventListener('click', () => closeModalView());
+}
+
+if(modal){
+  modal.addEventListener('click', (event) => {
+    if(event.target === modal){
+      closeModalView();
+    }
+  });
+}
+
+window.addEventListener('keydown', (event) => {
+  if(event.key === 'Escape' && activeStudentId){
+    closeModalView();
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  if(teacherCanvasApp?.destroy){
+    teacherCanvasApp.destroy();
+  }
+});
+
+const savedSession = (() => {
+  try{
+    return localStorage.getItem(STORAGE_KEY);
+  }catch(err){
+    return null;
+  }
+})();
+
+if(savedSession){
+  if(sessionInput){
+    sessionInput.value = savedSession;
+  }
+  startSession({ announce: true });
+}else{
+  renderStudents();
+}
+
+export {}; // keep module scope

--- a/teacher-supabase.html
+++ b/teacher-supabase.html
@@ -140,28 +140,6 @@
     window.SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5dHN3c3plb3BkeG10eHhia3JiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg1NTI5ODQsImV4cCI6MjA3NDEyODk4NH0.7skddGtrUoXluvK9JDS54bpmKCxVYeofzWATmJIgABE";
   </script>
 
-  <script type="module">
-    import initCanvasApp from './canvas-app.js';
-
-    initCanvasApp({
-      root: document.getElementById('teacherCanvasApp'),
-      stage: document.getElementById('teacherStage'),
-      canvas: document.getElementById('teacherPad'),
-      colorButtons: [...document.querySelectorAll('#teacherCanvasApp [data-color]')],
-      toolButtons: [...document.querySelectorAll('#teacherCanvasApp [data-tool]')],
-      undoButton: document.getElementById('teacherUndoBtn'),
-      redoButton: document.getElementById('teacherRedoBtn'),
-      clearButton: document.getElementById('teacherClearBtn'),
-      stylusToggle: document.getElementById('teacherStylusBtn'),
-      sizeSlider: document.getElementById('teacherBrush'),
-      sizeLabel: document.getElementById('teacherSizeLabel'),
-      sizePreview: document.getElementById('teacherSizePreview'),
-      statusElement: document.getElementById('teacherCanvasStatus'),
-      statusText: document.getElementById('teacherCanvasStatusText'),
-      role: 'teacher',
-      remoteLabel: 'student',
-      channelName: 'classroom-canvas',
-    });
-  </script>
+  <script type="module" src="./teacher-app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated student module that manages login validation, status updates, and presence broadcasts
- build a teacher dashboard module that tracks active students and opens the annotation workspace
- wire both HTML pages to the new modules and surface clearer connection messaging

## Testing
- python3 -m http.server 8000 (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68dd012212108327955799ea39e9c334